### PR TITLE
ONSIP-2435: Added class 'onsip-disable-clicktocall'

### DIFF
--- a/onsip/js/content_page.js
+++ b/onsip/js/content_page.js
@@ -116,7 +116,7 @@ function parseDOM (node) {
   var nodeName = node && node.nodeName && node.nodeName.toUpperCase() || '';
   var childNodesLength = node && node.childNodes.length || 0;
 
-  if (!node || $.inArray(nodeName, INVALID_NODES) > -1 || $(node).hasClass('onsip-message-box')) {
+  if (!node || $.inArray(nodeName, INVALID_NODES) > -1 || $(node).hasClass('onsip-message-box') || $(node).hasClass('onsip-disable-clicktocall')) {
     return 0;
   }
 


### PR DESCRIPTION
The extension behaviour will be ignored if class 'onsip-disable-clicktocall' is added to a node